### PR TITLE
Fix the problem of redirecting the invite message incorrectly to the previous server address after receiving the 302 message

### DIFF
--- a/src/sal/op.cpp
+++ b/src/sal/op.cpp
@@ -374,6 +374,7 @@ int SalOp::processRedirect () {
 	/* remove previously used authorization headers. */
 	belle_sip_message_remove_header(BELLE_SIP_MESSAGE(request), BELLE_SIP_AUTHORIZATION);
 	belle_sip_message_remove_header(BELLE_SIP_MESSAGE(request), BELLE_SIP_PROXY_AUTHORIZATION);
+    mRouteAddresses.clear();
 	sendRequest(request);
 	return 0;
 }


### PR DESCRIPTION
Fix the problem of redirecting the invite message incorrectly to the previous server address after receiving the 302 message
in linphone 4.3 after received 302 message and server send second ip address in contact header, Linphone still sending to previous server when it wants to send invite message after receiving 302 message.

example:
received [432] new bytes from [TCP://91.200.50.152:14777]:
SIP/2.0 302 Moved Temporarily!
...
Contact: <sip: ... @91.200.50.154:14777;transport=tcp>
...

message sent to [TCP://91.200.50.152:14777], size: [1442] bytes:
INVITE sip:...@91.200.50.154:14777;transport=tcp SIP/2.0
....
From: "..." <sip: .... @91.200.50.152>...
To: "..." <sip:.... @91.200.50.154>
......