### PR TITLE
Fix daemon exception if config key isn't present

### DIFF
--- a/daemon/commands/config.cc
+++ b/daemon/commands/config.cc
@@ -48,7 +48,7 @@ void ConfigGetCommand::exec(Daemon *app, const string& args) {
 		app->sendResponse(Response("Missing section and/or key names."));
 		return;
 	}
-	const char *read_value=linphone_config_get_string(linphone_core_get_config(app->getCore()),section.c_str(),key.c_str(),NULL);
+	const char *read_value=linphone_config_get_string(linphone_core_get_config(app->getCore()),section.c_str(),key.c_str(), "<unset>");
 	app->sendResponse(ConfigResponse(read_value));
 }
 


### PR DESCRIPTION
Currently linphone-daemon crashes if you try to read a config key/value which isn't present because `NULL` is passed to the  `ConfigResponse` constructor:

```
selenium usr/bin » ./linphone-daemon --pipe lpdaemon --config test-config & sleep 1 && (echo "config-get baz bar" | nc -U /tmp/lpdaemon)
[1] 10721
Server unix socket created, name=lpdaemon fd=3
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
[1]  + 10721 abort      ./linphone-daemon --pipe lpdaemon --config test-config
```

With my change applied, the command behaves like documented:
```
selenium usr/bin » ./linphone-daemon --pipe lpdaemon --config test-config & sleep 1 && (echo "config-get baz bar" | nc -U /tmp/lpdaemon)
[1] 4366
Server unix socket created, name=lpdaemon fd=3
Status: Ok

Value: <unset>
```