### PR TITLE
Notify DTMF received also in pipe

### DIFF
--- a/console/linphonec.c
+++ b/console/linphonec.c
@@ -370,8 +370,7 @@ linphonec_text_received(LinphoneCore *lc, LinphoneChatRoom *cr,
 
 static void linphonec_dtmf_received(LinphoneCore *lc, LinphoneCall *call, int dtmf){
 	char *from=linphone_call_get_remote_address_as_string(call);
-	fprintf(stdout,"Receiving tone %c from %s\n",dtmf,from);
-	fflush(stdout);
+	linphonec_out("Receiving tone %c from %s\n",dtmf,from);
 	ms_free(from);
 }
 


### PR DESCRIPTION
## Before the change
When a DTMF tone is received, a message is sent to linphonec output only.

## After the change
When a DTMF tone is received, a message is also sent to the pipe created by linphone-daemon.  
The behaviour looks coherent to what happens with call messages, but I am admittedly not sure if this could break someone's workflow.  

Would you consider merging this? This is my first time working with linphone and voip in general, so if you won't, that's fine.