### PR TITLE
Add pkgconfig support for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,6 +462,14 @@ configure_package_config_file(cmake/LinphoneConfig.cmake.in
 	NO_SET_AND_CHECK_MACRO
 )
 
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix ${prefix}/${CMAKE_INSTALL_BINDIR})
+set(libdir ${prefix}/${CMAKE_INSTALL_LIBDIR})
+set(includedir ${prefix}/include)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/linphone.pc.in ${CMAKE_CURRENT_BINARY_DIR}/linphone.pc)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/linphone.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 install(EXPORT ${EXPORT_TARGETS_NAME}Targets
 	FILE LinphoneTargets.cmake
 	DESTINATION ${CONFIG_PACKAGE_LOCATION}

--- a/linphone.pc.in
+++ b/linphone.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+includedir=@includedir@
+
+Name: linphone
+Description: A free (GPL) video softphone based on the SIP protocol
+Requires:
+Version: @VERSION@
+Libs: -L@libdir@ -llinphone
+Libs.private: @LIBS_PRIVATE@
+Cflags: -I@includedir@


### PR DESCRIPTION
This patch add the creation of the `linphone.pc` file used by the pkg-config tool.
The file provide the necessary details for compiling and linking liblinphone and look like this when generated :
```
prefix=/usr
exec_prefix=/usr/bin
includedir=/usr/include

Name: linphone
Description: A free (GPL) video softphone based on the SIP protocol
Requires:
Version: 
Libs: -L/usr/lib -llinphone
Libs.private: 
Cflags: -I/usr/include
```