### PR TITLE
Fix build with clang 15

### DIFF
--- a/console/linphonec.c
+++ b/console/linphonec.c
@@ -962,7 +962,7 @@ static void lpc_apply_video_params(void){
  *
  */
 static int
-linphonec_idle_call ()
+linphonec_idle_call (void)
 {
 	LinphoneCore *opm=linphonec;
 
@@ -1271,7 +1271,7 @@ linphonec_parse_cmdline(int argc, char **argv)
  *	-1 on error
  */
 static int
-handle_configfile_migration()
+handle_configfile_migration(void)
 {
 #if !defined(_WIN32_WCE)
 	char *old_cfg_gui;


### PR DESCRIPTION
The -Wstrict-prototype got stricter with clang 15. This causes build failures due to two missing void.

```
/tmp/pobj/liblinphone-5.1.56/liblinphone-5.1.56/console/linphonec.c:968:21: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
linphonec_idle_call ()
                    ^
                     void
```