### PR TITLE
config option request: on receipt of PN reply always with REGISTER refresh

### DIFF
--- a/src/account/account-params.cpp
+++ b/src/account/account-params.cpp
@@ -86,6 +86,7 @@ AccountParams::AccountParams(LinphoneCore *lc) {
 	mPushNotificationAllowed =
 	    lc ? !!linphone_config_get_default_int(lc->config, "proxy", "push_notification_allowed", pushAllowedDefault)
 	       : pushAllowedDefault;
+	mPushNotificationReplyWRegisterAlways = lc ? !!linphone_config_get_default_int(lc->config, "proxy", "push_reply_register_always", 0) : 0;
 	mRemotePushNotificationAllowed =
 	    lc ? !!linphone_config_get_default_int(lc->config, "proxy", "remote_push_notification_allowed",
 	                                           remotePushAllowedDefault)
@@ -383,6 +384,10 @@ void AccountParams::setPushNotificationAllowed(bool allow) {
 	mPushNotificationAllowed = allow;
 }
 
+void AccountParams::setPushNotificationReplyWRegisterAlways(bool allow) {
+	mPushNotificationReplyWRegisterAlways = allow;
+}
+
 void AccountParams::setRemotePushNotificationAllowed(bool allow) {
 	mRemotePushNotificationAllowed = allow;
 }
@@ -566,6 +571,10 @@ uint8_t AccountParams::getAvpfRrInterval() const {
 
 bool AccountParams::getRegisterEnabled() const {
 	return mRegisterEnabled;
+}
+
+bool AccountParams::getPushNotificationReplyWRegisterAlways() const {
+	return mPushNotificationReplyWRegisterAlways;
 }
 
 bool AccountParams::getDialEscapePlusEnabled() const {

--- a/src/account/account-params.h
+++ b/src/account/account-params.h
@@ -56,6 +56,7 @@ public:
 	void setPublishEnabled(bool enable);
 	void setOutboundProxyEnabled(bool enable);
 	void setPushNotificationAllowed(bool allow);
+	void setPushNotificationReplyWRegisterAlways(bool enable);
 	void setRemotePushNotificationAllowed(bool allow);
 	void setUseInternationalPrefixForCallsAndChats(bool enable);
 	void setCpimMessagesAllowedInBasicChatRooms(bool allow);
@@ -95,6 +96,7 @@ public:
 	bool getPublishEnabled() const;
 	bool getOutboundProxyEnabled() const;
 	bool getPushNotificationAllowed() const;
+	bool getPushNotificationReplyWRegisterAlways() const;
 	bool getRemotePushNotificationAllowed() const;
 	bool getUseInternationalPrefixForCallsAndChats() const;
 	bool isPushNotificationAvailable() const;
@@ -152,6 +154,7 @@ private:
 	bool mQualityReportingEnabled;
 	bool mPublishEnabled;
 	bool mPushNotificationAllowed;
+	bool mPushNotificationReplyWRegisterAlways;
 	bool mRemotePushNotificationAllowed;
 	bool mUseInternationalPrefixForCallsAndChats;
 	bool mRtpBundleEnabled;

--- a/src/c-wrapper/api/c-account-params.cpp
+++ b/src/c-wrapper/api/c-account-params.cpp
@@ -220,6 +220,10 @@ bool_t linphone_account_params_register_enabled(const LinphoneAccountParams *par
 	return AccountParams::toCpp(params)->getRegisterEnabled();
 }
 
+bool_t linphone_account_params_get_PushNotificationReplyWRegisterAlways(const LinphoneAccountParams *params) {
+	return AccountParams::toCpp(params)->getPushNotificationReplyWRegisterAlways();
+}
+
 const char *linphone_account_params_get_contact_parameters(const LinphoneAccountParams *params) {
 	return L_STRING_TO_C(AccountParams::toCpp(params)->getContactParameters());
 }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1312,6 +1312,16 @@ void Core::pushNotificationReceived(const string &callId, const string &payload,
 	bool sendKeepAlive = false;
 	while (it) {
 		LinphoneProxyConfig *proxy = (LinphoneProxyConfig *)bctbx_list_get_data(it);
+
+		// check if SIP proxy server requires to always reply with REGISTER request (refresh) 
+		LinphoneAccountParams *params = linphone_account_get_params(proxy->account);
+		bool sendRegisterAlways = linphone_account_params_get_PushNotificationReplyWRegisterAlways(params);
+		if (sendRegisterAlways) {
+			lInfo() << "Proxy config [" << proxy << "] requires to always reply by sending REGISTER request, refreshing REGISTER";
+			linphone_proxy_config_refresh_register(proxy);
+			continue;
+		}
+		
 		LinphoneRegistrationState state = linphone_proxy_config_get_state(proxy);
 		if (state == LinphoneRegistrationFailed) {
 			lInfo() << "Proxy config [" << proxy << "] is in failed state, refreshing REGISTER";


### PR DESCRIPTION
@Viish
 
Some SIP proxies  expect the SIP clients to always/unconditionally send a REGISTER (refresh) request  in reply to a  received push notification  (c.f. e.g. OpenSIPS, c.f. https://opensips.org/docs/modules/3.3.x/registrar.html#param_pn_refresh_timeout)

The attached code therefore seeks to implement such behavior alongside a new configurable option within AccountParams class [->(boolean) push_reply_register_always], to configure whether to always respond to received push notifications by sending a REGISTER refresh.

**DISCLAIMER**
The attached code has not yet been tested due to the lack of a working build environment for liblinphone.
