### PR TITLE
Update lpc2xml.c

### DIFF
--- a/coreapi/lpc2xml.c
+++ b/coreapi/lpc2xml.c
@@ -21,6 +21,7 @@
 #include "lpc2xml.h"
 #include <libxml/xmlsave.h>
 #include <libxml/xmlversion.h>
+#include <libxml/xmlerror.h>
 #include <string.h>
 
 #define LPC2XML_BZ 2048


### PR DESCRIPTION
Fix undeclared `xmlSetGenericErrorFunc` in `coreapi/lpc2xml.c`

When building v5.3.58 I got the following compile error:
```
coreapi/lpc2xml.c:299:9: error: 'xmlSetGenericErrorFunc' was not declared in this scope
```