### PR TITLE
Fix memory leak on iOS shared core helper

### DIFF
--- a/src/core/shared-core-helpers/ios-shared-core-helpers.mm
+++ b/src/core/shared-core-helpers/ios-shared-core-helpers.mm
@@ -353,7 +353,10 @@ void IosSharedCoreHelpers::cleanUserDefaultsMessages() {
 	NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@(mAppGroupId.c_str())];
 
 	NSDictionary *msgDictionary = [defaults dictionaryForKey:@"messages"];
-	if (msgDictionary == nil) return;
+	if (msgDictionary == nil) {
+		[defaults release];
+		return;
+	}
 	NSMutableDictionary *messages = [[NSMutableDictionary alloc] initWithDictionary:msgDictionary];
 
 	NSArray<NSString *> *callIds = [messages allKeys];


### PR DESCRIPTION
## Description
This PR fixes memory leak in one of iOS shared core helpers, whenever user defaults do not contain messages object.

![Screenshot 2024-07-18 at 14 30 38](https://github.com/user-attachments/assets/d653af74-5818-4a39-83b4-d4b076cd4de1)
![Screenshot 2024-07-18 at 14 30 45](https://github.com/user-attachments/assets/a650da67-2d67-4438-a264-3d3bff1a107b)

## How to reproduce
* linphone lib integrated with iOS app.
* Shared linphone core initialised with configuration:
```
       let config = Config.newForSharedCore(
                   appGroupId: ...,
                   configFilename: ...,
                   factoryConfigFilename: ...
       )

        do {
            core = try Factory.Instance.createSharedCoreWithConfig(
                config: config,
                systemContext: nil,
                appGroupId: ...,
                mainCore: true
            )
        }  catch {
            return nil
        }
```
* Run the app.
* Put a breakpoint right after core initialization. Open Xcodes object graph debugger. Turn on "leaked objects" filter.

## How fix works
I think code is self explanatory :) It's all about missing `release()` call.