### PR TITLE
Fix calls being declined automatically on reception when defining a call timeout

### DIFF
--- a/src/conference/session/call-session.cpp
+++ b/src/conference/session/call-session.cpp
@@ -1727,7 +1727,7 @@ void CallSession::iterate(time_t currentRealTime, bool oneSecondElapsed) {
 
 	const auto callTimeout = getCore()->getCCore()->sip_conf.in_call_timeout;
 	const auto &connectedTime = d->log->getConnectedTime();
-	if ((callTimeout > 0) && (connectedTime != 0) && ((currentRealTime - connectedTime) > callTimeout)) {
+	if ((callTimeout > 0) && (connectedTime != -1) && ((currentRealTime - connectedTime) > callTimeout)) {
 		lInfo() << "Terminating call session " << this << " (local address " << *getLocalAddress() << " remote address "
 		        << (getRemoteAddress() ? getRemoteAddress()->toString() : "sip:") << ") because the call timeout ("
 		        << callTimeout << "s) has been reached";


### PR DESCRIPTION
The commit [fe504f0e40875e4cc4e729b13422ec277760008d](https://github.com/BelledonneCommunications/liblinphone/commit/fe504f0e40875e4cc4e729b13422ec277760008d) introduced a bug which causes liblinphone to decline every call on reception when a call timeout is configured.

The commit `fe504f0e` changed the default value of `mConnectedTime` (Connecting date of the call in seconds as expressed in a time_t) from 0 to -1, but did not apply this change to the condition checking if the call duration should be compared with the call timeout parameter, to stop the call. The condition checks if `mConnectedTime` has been set by comparing it to its old default value (0) instead of the new one (-1).