### PR TITLE
Fix Liblinphone intersects with other libraries with "time.h" inside

### DIFF
--- a/include/linphone/api/c-participant-device.h
+++ b/include/linphone/api/c-participant-device.h
@@ -21,7 +21,7 @@
 #ifndef _L_C_PARTICIPANT_DEVICE_H_
 #define _L_C_PARTICIPANT_DEVICE_H_
 
-#include "time.h"
+#include <time.h>
 
 #include "linphone/api/c-participant-device-cbs.h"
 #include "linphone/api/c-types.h"

--- a/include/linphone/api/c-participant.h
+++ b/include/linphone/api/c-participant.h
@@ -22,7 +22,7 @@
 #define _L_C_PARTICIPANT_H_
 
 #include "linphone/api/c-types.h"
-#include "time.h"
+#include <time.h>
 
 // =============================================================================
 


### PR DESCRIPTION
This merge request fixes the issue https://github.com/BelledonneCommunications/liblinphone/issues/207, which describes how the library cannot be used in a React Native project.